### PR TITLE
feat(oss): graph hover breakdown + compact Key Contributions leaderboard

### DIFF
--- a/apps/web/src/app/(web)/oss/page.tsx
+++ b/apps/web/src/app/(web)/oss/page.tsx
@@ -104,14 +104,6 @@ export default async function OSSPage() {
           <ContributionGraph data={monthly} />
         </div>
 
-        {/* Timeline */}
-        <h2 className="mb-6 font-bold font-display text-2xl text-site-text">
-          Journey
-        </h2>
-        <div className="mb-12">
-          <Timeline />
-        </div>
-
         {/* Contributions */}
         <h2 className="mb-2 font-bold font-display text-2xl text-site-text">
           Key Contributions
@@ -119,7 +111,7 @@ export default async function OSSPage() {
         <p className="mb-6 text-site-text-secondary text-sm">
           Every repo where I have more than one contribution — live from GitHub.
         </p>
-        <div className="grid gap-4 sm:grid-cols-2">
+        <div className="mb-12 grid gap-4 sm:grid-cols-2">
           {contributions.map((c) => (
             <a
               key={c.fullName}
@@ -156,6 +148,14 @@ export default async function OSSPage() {
               </Card>
             </a>
           ))}
+        </div>
+
+        {/* Timeline */}
+        <h2 className="mb-6 font-bold font-display text-2xl text-site-text">
+          Journey
+        </h2>
+        <div>
+          <Timeline />
         </div>
       </Container>
     </main>

--- a/apps/web/src/app/(web)/oss/page.tsx
+++ b/apps/web/src/app/(web)/oss/page.tsx
@@ -11,7 +11,6 @@ import type { Metadata } from "next";
 import { Container } from "@/components/container";
 import { ContributionGraph } from "@/components/oss/contribution-graph";
 import { Timeline } from "@/components/oss/timeline";
-import { Card, CardContent } from "@/components/ui/card";
 import { siteConfig } from "@/config/site";
 
 export const metadata: Metadata = {
@@ -44,6 +43,8 @@ export default async function OSSPage() {
 
   const currentYear = monthly.at(-1)?.year ?? ossStartYear;
   const yearsActive = currentYear - ossStartYear;
+
+  const maxRepoCommits = Math.max(...contributions.map((c) => c.commits), 1);
 
   const stats = [
     {
@@ -111,41 +112,49 @@ export default async function OSSPage() {
         <p className="mb-6 text-site-text-secondary text-sm">
           Every repo where I have more than one contribution — live from GitHub.
         </p>
-        <div className="mb-12 grid gap-4 sm:grid-cols-2">
+        <div className="mb-12 divide-y divide-site-border overflow-hidden rounded-xl border border-site-border bg-site-card dark:divide-white/4 dark:border-white/4 dark:bg-linear-to-br dark:from-site-card dark:to-site-bg-secondary">
           {contributions.map((c) => (
             <a
               key={c.fullName}
               href={repoUrl(c.fullName, c.org)}
               target="_blank"
               rel="nofollow noopener noreferrer"
-              className="group block"
+              className="group relative isolate flex flex-col gap-1.5 overflow-hidden px-4 py-3 sm:flex-row sm:items-center sm:gap-4 sm:px-5"
             >
-              <Card className="relative h-full overflow-hidden border border-site-border/50 bg-site-card transition-all duration-200 group-hover:-translate-y-0.5 group-hover:border-site-border-hover group-hover:shadow-xl/5 dark:border-white/4 dark:bg-linear-to-br dark:from-site-card dark:to-site-bg-secondary dark:group-hover:border-white/10 dark:group-hover:shadow-site-accent-subtle">
-                <CardContent className="flex h-full flex-col p-5">
-                  <div className="mb-2 flex items-center gap-2">
-                    <GitHubLogoIcon className="h-3.5 w-3.5 shrink-0 text-site-text-tertiary" />
-                    <h3 className="truncate font-display font-semibold text-[15px] text-site-text">
-                      {c.name}
-                    </h3>
-                    <span className="ml-auto shrink-0 rounded-md bg-site-accent-subtle px-2 py-0.5 font-mono text-[10px] text-site-accent">
-                      {c.org}
-                    </span>
-                  </div>
-                  {c.description && (
-                    <p className="mb-3 line-clamp-2 text-[13px] text-site-text-secondary leading-relaxed">
-                      {c.description}
-                    </p>
-                  )}
-                  <div className="mt-auto flex flex-wrap items-center gap-x-3 gap-y-1 font-mono text-[11px] text-site-text-tertiary">
-                    <span className="text-site-accent">
-                      {c.commits} commits
-                    </span>
-                    {c.prs > 0 && <span>{c.prs} PRs</span>}
-                    <span>★ {formatCount(c.stars)}</span>
-                    <span>⑂ {formatCount(c.forks)}</span>
-                  </div>
-                </CardContent>
-              </Card>
+              {/* Commit-volume bar — ranks repos at a glance */}
+              <span
+                aria-hidden
+                className="absolute inset-y-0 left-0 -z-10 bg-site-accent-subtle transition-all duration-300 group-hover:bg-site-accent/15"
+                style={{
+                  width: `${Math.max((c.commits / maxRepoCommits) * 100, 5)}%`,
+                }}
+              />
+
+              {/* Repo + org */}
+              <div className="flex items-center gap-2 sm:w-60 sm:shrink-0">
+                <GitHubLogoIcon className="h-3.5 w-3.5 shrink-0 text-site-text-tertiary transition-colors group-hover:text-site-accent" />
+                <h3 className="truncate font-display font-semibold text-[15px] text-site-text">
+                  {c.name}
+                </h3>
+                <span className="ml-auto shrink-0 rounded-md bg-site-accent-subtle px-2 py-0.5 font-mono text-[10px] text-site-accent sm:ml-0">
+                  {c.org}
+                </span>
+              </div>
+
+              {/* Description (wide screens only) */}
+              {c.description && (
+                <p className="hidden min-w-0 flex-1 truncate text-[13px] text-site-text-secondary md:block">
+                  {c.description}
+                </p>
+              )}
+
+              {/* Stats */}
+              <div className="flex items-center gap-x-3 font-mono text-[11px] text-site-text-tertiary sm:ml-auto sm:shrink-0">
+                <span className="text-site-accent">{c.commits} commits</span>
+                {c.prs > 0 && <span>{c.prs} PRs</span>}
+                <span>★ {formatCount(c.stars)}</span>
+                <span>⑂ {formatCount(c.forks)}</span>
+              </div>
             </a>
           ))}
         </div>

--- a/apps/web/src/app/(web)/oss/page.tsx
+++ b/apps/web/src/app/(web)/oss/page.tsx
@@ -141,9 +141,12 @@ export default async function OSSPage() {
                 </span>
               </div>
 
-              {/* Description (wide screens only) */}
+              {/* Description (wide screens only) — capped width, full text on hover */}
               {c.description && (
-                <p className="hidden min-w-0 flex-1 truncate text-[13px] text-site-text-secondary md:block">
+                <p
+                  title={c.description}
+                  className="hidden min-w-0 shrink truncate text-[13px] text-site-text-secondary md:block md:max-w-xs lg:max-w-md"
+                >
                   {c.description}
                 </p>
               )}

--- a/apps/web/src/components/oss/contribution-graph.tsx
+++ b/apps/web/src/components/oss/contribution-graph.tsx
@@ -36,13 +36,42 @@ export function ContributionGraph({ data }: { data: MonthlyContribution[] }) {
               className="group flex h-full flex-1 flex-col items-center justify-end gap-2"
             >
               <div className="relative flex w-full flex-1 items-end justify-center">
-                <span className="pointer-events-none absolute bottom-full left-1/2 mb-1.5 -translate-x-1/2 whitespace-nowrap rounded-md border border-site-border bg-site-bg-tertiary px-2 py-0.5 font-mono text-[10px] text-site-text opacity-0 transition-opacity duration-150 group-hover:opacity-100">
-                  {d.commits} · {d.label} {d.year}
-                </span>
+                {/* Hover breakdown card */}
+                <div className="pointer-events-none absolute bottom-full left-1/2 z-10 mb-2 w-44 -translate-x-1/2 rounded-lg border border-site-border bg-site-card p-3 opacity-0 shadow-black/10 shadow-xl transition-opacity duration-150 group-hover:opacity-100 dark:border-white/8 dark:bg-site-bg-tertiary">
+                  <div className="flex items-baseline justify-between gap-2 border-site-border/60 border-b pb-1.5">
+                    <span className="font-display font-semibold text-site-text text-xs">
+                      {d.label} {d.year}
+                    </span>
+                    <span className="font-mono text-[11px] text-site-accent">
+                      {d.commits} commit{d.commits === 1 ? "" : "s"}
+                    </span>
+                  </div>
+                  {d.byRepo.length > 0 ? (
+                    <ul className="mt-2 space-y-1">
+                      {d.byRepo.map((r) => (
+                        <li
+                          key={r.repo}
+                          className="flex items-center justify-between gap-2 font-mono text-[11px]"
+                        >
+                          <span className="truncate text-site-text-secondary">
+                            {r.name}
+                          </span>
+                          <span className="shrink-0 text-site-text-tertiary">
+                            {r.commits}
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <p className="mt-2 font-mono text-[11px] text-site-text-tertiary">
+                      No contributions
+                    </p>
+                  )}
+                </div>
+
                 <div
                   className="w-full rounded-t-sm bg-linear-to-t from-site-accent/25 to-site-accent transition-all duration-200 group-hover:from-site-accent/40 group-hover:to-site-accent-hover"
                   style={{ height: `${heightPct}%` }}
-                  title={`${d.commits} commits in ${d.label} ${d.year}`}
                 />
               </div>
               <span className="font-mono text-[10px] text-site-text-tertiary">

--- a/packages/github/data/snapshot.json
+++ b/packages/github/data/snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-25T18:59:30.373Z",
+  "generatedAt": "2026-06-25T19:09:09.713Z",
   "stars": 703,
   "contributions": 422,
   "lightningCommits": 350,
@@ -312,73 +312,407 @@
       "label": "Jul",
       "year": 2025,
       "month": 6,
-      "commits": 13
+      "commits": 13,
+      "byRepo": [
+        {
+          "repo": "Lightning-AI/litdata",
+          "name": "litdata",
+          "commits": 7
+        },
+        {
+          "repo": "Lightning-AI/LitServe",
+          "name": "LitServe",
+          "commits": 5
+        },
+        {
+          "repo": "Lightning-AI/pytorch-lightning",
+          "name": "pytorch-lightning",
+          "commits": 1
+        }
+      ]
     },
     {
       "label": "Aug",
       "year": 2025,
       "month": 7,
-      "commits": 26
+      "commits": 26,
+      "byRepo": [
+        {
+          "repo": "Lightning-AI/pytorch-lightning",
+          "name": "pytorch-lightning",
+          "commits": 14
+        },
+        {
+          "repo": "Lightning-AI/litdata",
+          "name": "litdata",
+          "commits": 8
+        },
+        {
+          "repo": "bhimrazy/receipt-ocr",
+          "name": "receipt-ocr",
+          "commits": 4
+        }
+      ]
     },
     {
       "label": "Sep",
       "year": 2025,
       "month": 8,
-      "commits": 11
+      "commits": 11,
+      "byRepo": [
+        {
+          "repo": "Lightning-AI/pytorch-lightning",
+          "name": "pytorch-lightning",
+          "commits": 6
+        },
+        {
+          "repo": "Lightning-AI/litdata",
+          "name": "litdata",
+          "commits": 2
+        },
+        {
+          "repo": "bhimrazy/receipt-ocr",
+          "name": "receipt-ocr",
+          "commits": 2
+        },
+        {
+          "repo": "Lightning-AI/LitServe",
+          "name": "LitServe",
+          "commits": 1
+        }
+      ]
     },
     {
       "label": "Oct",
       "year": 2025,
       "month": 9,
-      "commits": 36
+      "commits": 36,
+      "byRepo": [
+        {
+          "repo": "bhimrazy/receipt-ocr",
+          "name": "receipt-ocr",
+          "commits": 19
+        },
+        {
+          "repo": "Lightning-AI/pytorch-lightning",
+          "name": "pytorch-lightning",
+          "commits": 11
+        },
+        {
+          "repo": "Lightning-AI/litdata",
+          "name": "litdata",
+          "commits": 3
+        },
+        {
+          "repo": "Lightning-AI/LitServe",
+          "name": "LitServe",
+          "commits": 3
+        }
+      ]
     },
     {
       "label": "Nov",
       "year": 2025,
       "month": 10,
-      "commits": 37
+      "commits": 37,
+      "byRepo": [
+        {
+          "repo": "Lightning-AI/pytorch-lightning",
+          "name": "pytorch-lightning",
+          "commits": 12
+        },
+        {
+          "repo": "ekzhu/datasketch",
+          "name": "datasketch",
+          "commits": 11
+        },
+        {
+          "repo": "Lightning-AI/litgpt",
+          "name": "litgpt",
+          "commits": 9
+        },
+        {
+          "repo": "Lightning-AI/litdata",
+          "name": "litdata",
+          "commits": 5
+        }
+      ]
     },
     {
       "label": "Dec",
       "year": 2025,
       "month": 11,
-      "commits": 24
+      "commits": 24,
+      "byRepo": [
+        {
+          "repo": "Lightning-AI/pytorch-lightning",
+          "name": "pytorch-lightning",
+          "commits": 10
+        },
+        {
+          "repo": "ekzhu/datasketch",
+          "name": "datasketch",
+          "commits": 4
+        },
+        {
+          "repo": "Lightning-AI/LitServe",
+          "name": "LitServe",
+          "commits": 3
+        },
+        {
+          "repo": "Lightning-AI/litgpt",
+          "name": "litgpt",
+          "commits": 3
+        },
+        {
+          "repo": "Lightning-AI/litdata",
+          "name": "litdata",
+          "commits": 2
+        },
+        {
+          "repo": "Lightning-AI/torchmetrics",
+          "name": "torchmetrics",
+          "commits": 2
+        }
+      ]
     },
     {
       "label": "Jan",
       "year": 2026,
       "month": 0,
-      "commits": 39
+      "commits": 39,
+      "byRepo": [
+        {
+          "repo": "Lightning-AI/pytorch-lightning",
+          "name": "pytorch-lightning",
+          "commits": 11
+        },
+        {
+          "repo": "Lightning-AI/litdata",
+          "name": "litdata",
+          "commits": 6
+        },
+        {
+          "repo": "Lightning-AI/litgpt",
+          "name": "litgpt",
+          "commits": 6
+        },
+        {
+          "repo": "Lightning-AI/utilities",
+          "name": "utilities",
+          "commits": 6
+        },
+        {
+          "repo": "Lightning-AI/LitServe",
+          "name": "LitServe",
+          "commits": 4
+        },
+        {
+          "repo": "Lightning-AI/LitModels",
+          "name": "LitModels",
+          "commits": 3
+        },
+        {
+          "repo": "Lightning-AI/torchmetrics",
+          "name": "torchmetrics",
+          "commits": 2
+        },
+        {
+          "repo": "bhimrazy/receipt-ocr",
+          "name": "receipt-ocr",
+          "commits": 1
+        }
+      ]
     },
     {
       "label": "Feb",
       "year": 2026,
       "month": 1,
-      "commits": 19
+      "commits": 19,
+      "byRepo": [
+        {
+          "repo": "bhimrazy/receipt-ocr",
+          "name": "receipt-ocr",
+          "commits": 8
+        },
+        {
+          "repo": "Lightning-AI/utilities",
+          "name": "utilities",
+          "commits": 3
+        },
+        {
+          "repo": "Lightning-AI/LitServe",
+          "name": "LitServe",
+          "commits": 2
+        },
+        {
+          "repo": "Lightning-AI/litgpt",
+          "name": "litgpt",
+          "commits": 2
+        },
+        {
+          "repo": "Lightning-AI/torchmetrics",
+          "name": "torchmetrics",
+          "commits": 2
+        },
+        {
+          "repo": "Lightning-AI/LitModels",
+          "name": "LitModels",
+          "commits": 1
+        },
+        {
+          "repo": "Lightning-AI/pytorch-lightning",
+          "name": "pytorch-lightning",
+          "commits": 1
+        }
+      ]
     },
     {
       "label": "Mar",
       "year": 2026,
       "month": 2,
-      "commits": 27
+      "commits": 27,
+      "byRepo": [
+        {
+          "repo": "Lightning-AI/pytorch-lightning",
+          "name": "pytorch-lightning",
+          "commits": 8
+        },
+        {
+          "repo": "Lightning-AI/torchmetrics",
+          "name": "torchmetrics",
+          "commits": 7
+        },
+        {
+          "repo": "Lightning-AI/utilities",
+          "name": "utilities",
+          "commits": 4
+        },
+        {
+          "repo": "Lightning-AI/litdata",
+          "name": "litdata",
+          "commits": 3
+        },
+        {
+          "repo": "Lightning-AI/litgpt",
+          "name": "litgpt",
+          "commits": 3
+        },
+        {
+          "repo": "bhimrazy/receipt-ocr",
+          "name": "receipt-ocr",
+          "commits": 2
+        }
+      ]
     },
     {
       "label": "Apr",
       "year": 2026,
       "month": 3,
-      "commits": 10
+      "commits": 10,
+      "byRepo": [
+        {
+          "repo": "Lightning-AI/litgpt",
+          "name": "litgpt",
+          "commits": 3
+        },
+        {
+          "repo": "Lightning-AI/LitServe",
+          "name": "LitServe",
+          "commits": 2
+        },
+        {
+          "repo": "Lightning-AI/pytorch-lightning",
+          "name": "pytorch-lightning",
+          "commits": 2
+        },
+        {
+          "repo": "Lightning-AI/litdata",
+          "name": "litdata",
+          "commits": 1
+        },
+        {
+          "repo": "Lightning-AI/torchmetrics",
+          "name": "torchmetrics",
+          "commits": 1
+        },
+        {
+          "repo": "bhimrazy/receipt-ocr",
+          "name": "receipt-ocr",
+          "commits": 1
+        }
+      ]
     },
     {
       "label": "May",
       "year": 2026,
       "month": 4,
-      "commits": 25
+      "commits": 25,
+      "byRepo": [
+        {
+          "repo": "Lightning-AI/pytorch-lightning",
+          "name": "pytorch-lightning",
+          "commits": 10
+        },
+        {
+          "repo": "Lightning-AI/litgpt",
+          "name": "litgpt",
+          "commits": 4
+        },
+        {
+          "repo": "Lightning-AI/litdata",
+          "name": "litdata",
+          "commits": 3
+        },
+        {
+          "repo": "Lightning-AI/LitModels",
+          "name": "LitModels",
+          "commits": 3
+        },
+        {
+          "repo": "Lightning-AI/torchmetrics",
+          "name": "torchmetrics",
+          "commits": 2
+        },
+        {
+          "repo": "Lightning-AI/utilities",
+          "name": "utilities",
+          "commits": 2
+        },
+        {
+          "repo": "Lightning-AI/LitServe",
+          "name": "LitServe",
+          "commits": 1
+        }
+      ]
     },
     {
       "label": "Jun",
       "year": 2026,
       "month": 5,
-      "commits": 21
+      "commits": 21,
+      "byRepo": [
+        {
+          "repo": "Lightning-AI/litgpt",
+          "name": "litgpt",
+          "commits": 9
+        },
+        {
+          "repo": "Lightning-AI/LitServe",
+          "name": "LitServe",
+          "commits": 6
+        },
+        {
+          "repo": "Lightning-AI/utilities",
+          "name": "utilities",
+          "commits": 5
+        },
+        {
+          "repo": "Lightning-AI/LitLogger",
+          "name": "LitLogger",
+          "commits": 1
+        }
+      ]
     }
   ]
 }

--- a/packages/github/src/fetchers/contributions.ts
+++ b/packages/github/src/fetchers/contributions.ts
@@ -163,6 +163,15 @@ export async function getGitHubContributions(
   }
 }
 
+/** One repo's share of a single month's commits. */
+export type MonthlyRepoContribution = {
+  /** "owner/repo" slug. */
+  repo: string;
+  /** Short repo name (the part after the slash). */
+  name: string;
+  commits: number;
+};
+
 /** One month's commit total, used for the OSS contribution graph. */
 export type MonthlyContribution = {
   /** Short month name, e.g. "Jan". */
@@ -171,6 +180,8 @@ export type MonthlyContribution = {
   /** Zero-based month index (0 = January). */
   month: number;
   commits: number;
+  /** Per-repo split of `commits`, highest first; empty when nothing resolved. */
+  byRepo: MonthlyRepoContribution[];
 };
 
 /**
@@ -187,15 +198,19 @@ export async function getMonthlyContributions(
 ): Promise<MonthlyContribution[]> {
   const now = new Date();
   const buckets: MonthlyContribution[] = [];
+  // Per-month, per-repo tallies kept alongside `buckets` until we finalize them.
+  const repoTallies: Map<string, number>[] = [];
   const indexByKey = new Map<string, number>();
   for (let i = 11; i >= 0; i--) {
     const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
     indexByKey.set(`${d.getFullYear()}-${d.getMonth()}`, buckets.length);
+    repoTallies.push(new Map());
     buckets.push({
       label: d.toLocaleString("en-US", { month: "short" }),
       year: d.getFullYear(),
       month: d.getMonth(),
       commits: 0,
+      byRepo: [],
     });
   }
 
@@ -203,20 +218,36 @@ export async function getMonthlyContributions(
     const perRepo = await Effect.runPromise(
       Effect.all(
         repos.map((repo) =>
-          Effect.promise(() => fetchRepoWeeks(repo, username, 2, 500)),
+          Effect.promise(
+            async () =>
+              [repo, await fetchRepoWeeks(repo, username, 2, 500)] as const,
+          ),
         ),
         { concurrency: REQUEST_CONCURRENCY },
       ),
     );
 
-    for (const weeks of perRepo) {
+    for (const [repo, weeks] of perRepo) {
       if (!weeks) continue;
       for (const week of weeks) {
         if (week.c <= 0) continue;
         const d = new Date(week.w * 1000);
         const idx = indexByKey.get(`${d.getFullYear()}-${d.getMonth()}`);
-        if (idx !== undefined) buckets[idx].commits += week.c;
+        if (idx === undefined) continue;
+        buckets[idx].commits += week.c;
+        const tally = repoTallies[idx];
+        tally.set(repo, (tally.get(repo) ?? 0) + week.c);
       }
+    }
+
+    for (let i = 0; i < buckets.length; i++) {
+      buckets[i].byRepo = [...repoTallies[i]]
+        .map(([repo, commits]) => ({
+          repo,
+          name: repo.split("/")[1] ?? repo,
+          commits,
+        }))
+        .sort((a, b) => b.commits - a.commits);
     }
   } catch (error) {
     log.warn("monthly contributions error", { username }, error);

--- a/packages/github/src/index.ts
+++ b/packages/github/src/index.ts
@@ -23,6 +23,7 @@ export type {
   LightningAIEcosystemStats,
   LightningAIRepoStat,
   MonthlyContribution,
+  MonthlyRepoContribution,
   OSSStats,
   StarPoint,
 } from "./types";

--- a/packages/github/src/types.ts
+++ b/packages/github/src/types.ts
@@ -7,7 +7,10 @@ import type {
 } from "./fetchers/ecosystem";
 import type { FeaturedRepoStats } from "./fetchers/stars";
 
-export type { MonthlyContribution } from "./fetchers/contributions";
+export type {
+  MonthlyContribution,
+  MonthlyRepoContribution,
+} from "./fetchers/contributions";
 export type {
   ContributedRepo,
   LightningAIEcosystemStats,
@@ -83,11 +86,20 @@ const contributedRepoSchema = z.object({
   forks: z.number(),
 });
 
+const monthlyRepoContributionSchema = z.object({
+  repo: z.string(),
+  name: z.string(),
+  commits: z.number(),
+});
+
 const monthlyContributionSchema = z.object({
   label: z.string(),
   year: z.number(),
   month: z.number(),
   commits: z.number(),
+  // Optional for backward compatibility with snapshots written before the
+  // per-repo split existed; defaults to empty so existing data still parses.
+  byRepo: z.array(monthlyRepoContributionSchema).default([]),
 });
 
 /** Runtime guard used both when writing the snapshot and when reading it. */


### PR DESCRIPTION
## What does this PR do?

Polishes the **OSS page** with three changes:

- **Per-repo hover breakdown on the activity graph** — each month's bar now reveals which repos the commits came from, and how many. Required adding a `byRepo` split to the monthly contributions data (the fetcher already computed it; it was being summed away) plus a snapshot regen.
- **Reordered sections** — Key Contributions now sits above the Journey timeline.
- **Key Contributions redesign** — replaced the chunky 2-column card grid with a compact ranked leaderboard list (~half the height). A faint commit-volume bar fills each row proportional to contributions, descriptions are capped to a consistent width with full text on hover, and stats sit inline.

Also fixed a light-mode popover styling bug (border was the same color as the background → no visible edge).

## Notes
- The `byRepo` data is part of the committed snapshot and will keep refreshing via the daily sync Action.
- Verified in both light and dark themes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The OSS page now shows a richer “Key Contributions” view with commit-volume bars and a clearer stacked layout.
  * Hovering contribution graph bars now opens a detailed breakdown card with monthly totals and repo-level contribution counts.

* **Bug Fixes**
  * Contribution data now includes per-repository monthly breakdowns, improving accuracy in contribution summaries and hover details.

* **Style**
  * The OSS page layout and spacing were refreshed, and the timeline section was repositioned for a cleaner flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->